### PR TITLE
I've made some changes to address a potential memory leak in the watc…

### DIFF
--- a/apps/watcher/src/utils/logger.ts
+++ b/apps/watcher/src/utils/logger.ts
@@ -1,18 +1,14 @@
 import { subLogger } from '@yellow-mobile/logger'
 
-// export const logCdr = subLogger('CDR')
-// export const logPost = subLogger('POST')
-// export const logSimInnApi = subLogger('API')
-// export const logSimInnSMS = subLogger('SMS')
+export const logCdr = subLogger('CDR')
+export const logPost = subLogger('POST')
+export const logSimInnApi = subLogger('API')
+export const logSimInnSMS = subLogger('SMS')
 
 export const logCdrFilename = (filename: string) => subLogger(`CDR ${filename}`)
 
 export const createLoggers = () => {
-  const logCdr = subLogger('CDR')
-  const logPost = subLogger('POST')
-  const logSimInnApi = subLogger('API')
-  const logSimInnSMS = subLogger('SMS')
-
+  // Return the singleton instances
   return {
     logCdr,
     logPost,
@@ -21,9 +17,9 @@ export const createLoggers = () => {
   }
 }
 
-// export const loggers = [
-//   logCdr,
-//   logPost,
-//   logSimInnApi,
-//   logSimInnSMS
-// ]
+export const loggers = [
+  logCdr,
+  logPost,
+  logSimInnApi,
+  logSimInnSMS
+]


### PR DESCRIPTION
…her.

Here's what I did:
I refactored how loggers are created in `apps/watcher` to use single instances for the global loggers (CDR, Post, SimInnApi, SimInnSMS). I also modified the main application shutdown sequence in `index.ts` to explicitly close these loggers. This should prevent a situation where logger resources might not have been released, leading to a memory leak.

Additionally, I've added new unit tests to cover:
- Logger instance management and closure.
- Chokidar watcher cleanup.
- Node-schedule job cancellation.

You can find these tests in the `apps/watcher/test` directory.

IMPORTANT: I encountered some issues with the testing environment within the `apps/watcher` workspace. Specifically, Vitest was having trouble resolving its own modules (like 'vitest/config'). Because of this, I wasn't able to confirm that the new unit tests are passing successfully. I tried adding a Vitest configuration file (`apps/watcher/vitest.config.ts`) to address potential path alias problems, but the underlying environment issues remained. It would be a good idea to look into the test environment setup further.