### PR TITLE
I've aligned the ESLint rules and configurations in `packages/eslint-…

### DIFF
--- a/packages/eslint-config/index.cjs
+++ b/packages/eslint-config/index.cjs
@@ -1,5 +1,50 @@
 module.exports = {
-  rules: {
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
-  }
-}
+    extends: [
+        "plugin:jsdoc/recommended",
+        "plugin:import/typescript",
+        "@typescript-eslint/recommended",
+    ],
+    plugins: {
+        "no-only-tests": require("eslint-plugin-no-only-tests"),
+    },
+    languageOptions: {
+        globals: {
+            NodeJS: true,
+            $fetch: true,
+        },
+    },
+    settings: {
+        jsdoc: {
+            ignoreInternal: true,
+            tagNamePreference: {
+                warning: "warning",
+                note: "note",
+            },
+        },
+    },
+    rules: {
+        "sort-imports": ["error", {
+            ignoreDeclarationSort: true,
+        }],
+        "no-only-tests/no-only-tests": "error",
+        "no-console": "off",
+        "jsdoc/require-jsdoc": "off",
+        "jsdoc/require-param": "off",
+        "jsdoc/require-returns": "off",
+        "jsdoc/require-param-type": "off",
+        "no-redeclare": "off",
+        "@typescript-eslint/consistent-type-imports": ["error", {
+            disallowTypeAnnotations: false,
+        }],
+        "@typescript-eslint/ban-ts-comment": ["error", {
+            "ts-expect-error": "allow-with-description",
+            "ts-ignore": true,
+        }],
+        "@typescript-eslint/prefer-ts-expect-error": "error",
+        "@typescript-eslint/no-unused-vars": ["error", {
+            argsIgnorePattern: "^_",
+            varsIgnorePattern: "^_",
+            ignoreRestSiblings: true,
+        }],
+    },
+};


### PR DESCRIPTION
…config/index.cjs` (for the @yellow-mobile/eslint-config package) to match the rules you defined in the project's root `eslint.config.mjs` file.

This includes:
- Copying over rules, plugins, languageOptions, settings, and extends properties.
- Converting the configuration to CommonJS module format for `index.cjs`.
- Ensuring that dynamic or non-serializable parts of the root configuration were not directly copied, but their resolved values or equivalents were used (e.g., for `extends` and `plugins`).