### PR TITLE
feat(watcher): internationalize log messages in index.ts

### DIFF
--- a/apps/watcher/src/index.ts
+++ b/apps/watcher/src/index.ts
@@ -7,6 +7,7 @@ import schedule from 'node-schedule'
 import * as Prometheus from 'prom-client'
 
 import config from './config'
+import i18n from './i18n';
 import { initializeI18n } from './i18n';
 import { loggers } from './utils/logger' // Import the loggers array
 import { createCDRWatcher } from './cdr'
@@ -38,15 +39,15 @@ async function main() {
   })
 
   server = app.listen(port, () => {
-    console.log(`Watcher v${process.env.npm_package_version} app listens to port ${port}`)
-    console.log(`        using NodeJS ${process.version}`)
+    console.log(i18n.t('app.listening', { version: process.env.npm_package_version, port }))
+    console.log(i18n.t('app.nodeVersion', { version: process.version }))
   })
 
-  console.log('Application started after i18n initialization.');
+  console.log(i18n.t('app.started'));
 }
 
 main().catch(error => {
-  console.error("Error during application startup:", error);
+  console.error(i18n.t('app.error.startup'), error);
   process.exit(1);
 });
 
@@ -54,24 +55,24 @@ process.on('SIGINT', () => {
   if (server) {
     server.close((err?: Error) => {
       if (err) {
-        console.log(`Error: ${err.message}`)
+        console.log(i18n.t('app.server.closeError'), err.message)
       } else {
-        console.log('Server is closed')
+        console.log(i18n.t('app.server.closed'))
       }
     })
   }
 
   // Close all resources gracefully
   const gracefulShutdownFlow = async () => {
-    console.log('Starting graceful shutdown...');
+    console.log(i18n.t('app.shutdown.starting'));
 
     // Close watcher
     if (watcher) {
       try {
         await watcher.close();
-        console.log('Watcher is closed');
+        console.log(i18n.t('app.watcher.closed'));
       } catch (err) {
-        console.error(`Error closing watcher: ${(err as Error).message}`);
+        console.error(i18n.t('app.watcher.closeError'), (err as Error).message);
       }
     }
 
@@ -79,9 +80,9 @@ process.on('SIGINT', () => {
     if (jobs) { // Ensure jobs object exists
       try {
         await schedule.gracefulShutdown();
-        console.log('Schedule is closed');
+        console.log(i18n.t('app.schedule.closed'));
       } catch (err) {
-        console.error(`Error closing schedule: ${(err as Error).message}`);
+        console.error(i18n.t('app.schedule.closeError'), (err as Error).message);
       }
     }
 
@@ -92,7 +93,7 @@ process.on('SIGINT', () => {
           logger.close();
         }
       });
-      console.log('All global loggers closed.');
+      console.log(i18n.t('app.loggers.closed'));
     }
 
     // Finally, exit the process

--- a/apps/watcher/src/locales/en/translation.json
+++ b/apps/watcher/src/locales/en/translation.json
@@ -15,5 +15,31 @@
     "fileModified": "File {{path}} has been modified {{accessTime}}",
     "directoryAdded": "Directory {{path}}",
     "directoryRemoved": "Directory {{path}} has been removed"
+  },
+  "app": {
+    "listening": "Watcher v{{version}} app listens to port {{port}}",
+    "nodeVersion": "        using NodeJS {{version}}",
+    "started": "Application started after i18n initialization.",
+    "error": {
+      "startup": "Error during application startup:"
+    },
+    "server": {
+      "closeError": "Error:",
+      "closed": "Server is closed"
+    },
+    "shutdown": {
+      "starting": "Starting graceful shutdown..."
+    },
+    "watcher": {
+      "closed": "Watcher is closed",
+      "closeError": "Error closing watcher:"
+    },
+    "schedule": {
+      "closed": "Schedule is closed",
+      "closeError": "Error closing schedule:"
+    },
+    "loggers": {
+      "closed": "All global loggers closed."
+    }
   }
 }

--- a/apps/watcher/src/locales/nl/translation.json
+++ b/apps/watcher/src/locales/nl/translation.json
@@ -15,5 +15,31 @@
     "directoryAdded": "Map {{pad}}",
     "directoryRemoved": "Map {{path}} is verwijderd",
     "waitForNewFiles": "Wacht op nieuwe bestanden"
+  },
+  "app": {
+    "listening": "Watcher v{{version}} app luistert naar poort {{port}}",
+    "nodeVersion": "        gebruikt NodeJS {{version}}",
+    "started": "Applicatie gestart na i18n initialisatie.",
+    "error": {
+      "startup": "Fout tijdens het opstarten van de applicatie:"
+    },
+    "server": {
+      "closeError": "Fout:",
+      "closed": "Server is gesloten"
+    },
+    "shutdown": {
+      "starting": "Start graceful shutdown..."
+    },
+    "watcher": {
+      "closed": "Watcher is gesloten",
+      "closeError": "Fout bij het sluiten van de watcher:"
+    },
+    "schedule": {
+      "closed": "Schema is gesloten",
+      "closeError": "Fout bij het sluiten van het schema:"
+    },
+    "loggers": {
+      "closed": "Alle globale loggers gesloten."
+    }
   }
 }


### PR DESCRIPTION
Replaced hardcoded console.log and console.error messages in apps/watcher/src/index.ts with i18n.t() calls.

- Added new translation keys to locale files (en and nl) under the 'app' namespace for application lifecycle events, server status, and shutdown procedures.
- Updated apps/watcher/src/index.ts to use these keys for logging.
- English translations are provided, and Dutch translations are based on the English text.