### PR TITLE
feat: add currency-symbols.json to utils build

### DIFF
--- a/packages/utils/build.config.ts
+++ b/packages/utils/build.config.ts
@@ -11,6 +11,11 @@ export default defineBuildConfig([
       'src/converters/index.ts',
       'src/coverage/index.ts',
       'src/dates/index.ts',
+      {
+        builder: 'copy',
+        input: 'src/currency-symbols.json',
+        outDir: 'dist/currency-symbols.json',
+      },
     ],
     rollup: {
       emitCJS: true,


### PR DESCRIPTION
Adds a copy configuration to the build process for the @yellow-mobile/utils package. This ensures that the `src/currency-symbols.json` file is copied to `dist/currency-symbols.json` during the build.