### PR TITLE
feat: create @yellow-mobile/config package

### DIFF
--- a/packages/config/build.config.ts
+++ b/packages/config/build.config.ts
@@ -1,0 +1,12 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  declaration: true,
+  clean: true,
+  externals: [
+    // Add any external dependencies here, e.g. '@yellow-mobile/types'
+  ],
+  rollup: {
+    emitCJS: true
+  }
+})

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@yellow-mobile/config",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc -w"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,9 @@
+export const GREETING = "Hello from @yellow-mobile/config";
+
+export function loadConfig() {
+  console.log("Loading configuration...");
+  // In a real scenario, this function would load and return configuration.
+  return {
+    greeting: GREETING
+  };
+}

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,10 @@
     "types": [
       "node"
     ],
-    "paths": {}
+    "paths": {
+      "@yellow-mobile/config": ["packages/config/src"],
+      "@yellow-mobile/config/*": ["packages/config/src/*"]
+    }
   },
   "exclude": [
     "**/dist/**",


### PR DESCRIPTION
Adds a new TypeScript package named `@yellow-mobile/config`.

This package includes:
- Basic `package.json` setup.
- `tsconfig.json` extending the base configuration.
- `build.config.ts` for unbuild.
- An initial `src/index.ts` with a placeholder function.
- Updated root `tsconfig.json` with path alias for the new package.