### PR TITLE
feat: Add About page to web app

### DIFF
--- a/apps/web/app/app.vue
+++ b/apps/web/app/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
     <NuxtRouteAnnouncer />
-    <NuxtWelcome />
+    <NuxtPage />
   </div>
 </template>

--- a/apps/web/pages/about.vue
+++ b/apps/web/pages/about.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h1>About Us</h1>
+    <p>This is the About page for Yellow Mobile.</p>
+  </div>
+</template>


### PR DESCRIPTION
- Created the `pages` directory in `apps/web/`.
- Added a new `about.vue` page with basic placeholder content.
- Updated `apps/web/app/app.vue` to use `<NuxtPage />` component, enabling page routing for the Nuxt application.

This allows you to navigate to the `/about` path and view the new About page.